### PR TITLE
Fork changes

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 jobs:
   commitlint:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/decode.go
+++ b/decode.go
@@ -193,6 +193,14 @@ func (d *Decoder) IncludeUnexported(included bool) {
 	}
 }
 
+func (d *Decoder) SetForceAsArray(forced bool) {
+	if forced {
+		d.flags |= forceAsArrayFlag
+	} else {
+		d.flags &= ^forceAsArrayFlag
+	}
+}
+
 // Buffered returns a reader of the data remaining in the Decoder's buffer.
 // The reader is valid until the next call to Decode.
 func (d *Decoder) Buffered() io.Reader {

--- a/decode.go
+++ b/decode.go
@@ -24,6 +24,8 @@ const (
 	disallowUnknownFieldsFlag
 	usePreallocateValues
 	disableAllocLimitFlag
+	decodeIncludeUnexportedFlag
+	decodeForceAsArrayFlag
 )
 
 type bufReader interface {
@@ -187,17 +189,17 @@ func (d *Decoder) DisableAllocLimit(on bool) {
 // IncludeUnexported causes the Decoder to decode unexported fields
 func (d *Decoder) IncludeUnexported(included bool) {
 	if included {
-		d.flags |= includeUnexportedFlag
+		d.flags |= decodeIncludeUnexportedFlag
 	} else {
-		d.flags &= ^includeUnexportedFlag
+		d.flags &= ^decodeIncludeUnexportedFlag
 	}
 }
 
 func (d *Decoder) SetForceAsArray(forced bool) {
 	if forced {
-		d.flags |= forceAsArrayFlag
+		d.flags |= decodeForceAsArrayFlag
 	} else {
-		d.flags &= ^forceAsArrayFlag
+		d.flags &= ^decodeForceAsArrayFlag
 	}
 }
 

--- a/decode.go
+++ b/decode.go
@@ -93,9 +93,6 @@ func NewDecoder(r io.Reader) *Decoder {
 // reader to read from r.
 func (d *Decoder) Reset(r io.Reader) {
 	d.ResetDict(r, nil)
-	for k := range d.ignoredStructFields {
-		delete(d.ignoredStructFields, k)
-	}
 }
 
 // ResetDict is like Reset, but also resets the dict.

--- a/decode.go
+++ b/decode.go
@@ -74,8 +74,6 @@ type Decoder struct {
 	rec        []byte
 	dict       []string
 	flags      uint32
-
-	ignoredStructFields map[reflect.Type]map[string]struct{}
 }
 
 // NewDecoder returns a new decoder that reads from r.
@@ -193,18 +191,6 @@ func (d *Decoder) IncludeUnexported(included bool) {
 	} else {
 		d.flags &= ^includeUnexportedFlag
 	}
-}
-
-// IgnoreStructField causes the Decoder to ignore the field whose name is fieldName of the struct whose type is structType.
-// This method is similar to `msgpack:"-"` tag.
-func (d *Decoder) IgnoreStructField(structType reflect.Type, fieldName string) {
-	if d.ignoredStructFields == nil {
-		d.ignoredStructFields = make(map[reflect.Type]map[string]struct{})
-	}
-	if d.ignoredStructFields[structType] == nil {
-		d.ignoredStructFields[structType] = make(map[string]struct{})
-	}
-	d.ignoredStructFields[structType][fieldName] = struct{}{}
 }
 
 // Buffered returns a reader of the data remaining in the Decoder's buffer.

--- a/decode_hook.go
+++ b/decode_hook.go
@@ -1,0 +1,22 @@
+package msgpack
+
+import "reflect"
+
+type DecodeHook interface {
+	AfterMsgpackUnmarshal() error
+}
+
+func decodeHook(v reflect.Value) error {
+	if !v.CanAddr() {
+		return nil
+	}
+	if !v.CanSet() {
+		return nil
+	}
+	if hook, ok := v.Addr().Interface().(DecodeHook); ok {
+		if err := hook.AfterMsgpackUnmarshal(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/decode_map.go
+++ b/decode_map.go
@@ -310,7 +310,7 @@ func decodeStructValue(d *Decoder, v reflect.Value) error {
 		return nil
 	}
 
-	fields := structs.Fields(v.Type(), d.structTag, d.flags&includeUnexportedFlag != 0, d.flags&forceAsArrayFlag != 0)
+	fields := structs.Fields(v.Type(), d.structTag, d.flags&decodeIncludeUnexportedFlag != 0, d.flags&decodeForceAsArrayFlag != 0)
 	if n != len(fields.List) {
 		return errArrayStruct
 	}
@@ -334,7 +334,7 @@ func (d *Decoder) decodeStruct(v reflect.Value, n int) error {
 		return nil
 	}
 
-	fields := structs.Fields(v.Type(), d.structTag, d.flags&includeUnexportedFlag != 0, d.flags&forceAsArrayFlag != 0)
+	fields := structs.Fields(v.Type(), d.structTag, d.flags&decodeIncludeUnexportedFlag != 0, d.flags&decodeForceAsArrayFlag != 0)
 	for i := 0; i < n; i++ {
 		name, err := d.decodeStringTemp()
 		if err != nil {

--- a/decode_map.go
+++ b/decode_map.go
@@ -310,7 +310,7 @@ func decodeStructValue(d *Decoder, v reflect.Value) error {
 		return nil
 	}
 
-	fields := structs.Fields(v.Type(), d.structTag, d.flags&includeUnexportedFlag != 0, d.ignoredStructFields[v.Type()])
+	fields := structs.Fields(v.Type(), d.structTag, d.flags&includeUnexportedFlag != 0)
 	if n != len(fields.List) {
 		return errArrayStruct
 	}
@@ -334,7 +334,7 @@ func (d *Decoder) decodeStruct(v reflect.Value, n int) error {
 		return nil
 	}
 
-	fields := structs.Fields(v.Type(), d.structTag, d.flags&includeUnexportedFlag != 0, d.ignoredStructFields[v.Type()])
+	fields := structs.Fields(v.Type(), d.structTag, d.flags&includeUnexportedFlag != 0)
 	for i := 0; i < n; i++ {
 		name, err := d.decodeStringTemp()
 		if err != nil {

--- a/decode_map.go
+++ b/decode_map.go
@@ -94,7 +94,7 @@ func (d *Decoder) mapLen(c byte) (int, error) {
 }
 
 func decodeMapStringStringValue(d *Decoder, v reflect.Value) error {
-	mptr := v.Addr().Convert(mapStringStringPtrType).Interface().(*map[string]string)
+	mptr := d.reflectMapStringStringPtr(v.Addr().Convert(mapStringStringPtrType))
 	return d.decodeMapStringStringPtr(mptr)
 }
 

--- a/decode_map.go
+++ b/decode_map.go
@@ -266,7 +266,7 @@ func (d *Decoder) decodeTypedMapValue(v reflect.Value, n int) error {
 			return err
 		}
 
-		v.SetMapIndex(mk, mv)
+		d.reflectSetMapIndex(v, mk, mv)
 	}
 
 	return nil

--- a/decode_map.go
+++ b/decode_map.go
@@ -310,7 +310,7 @@ func decodeStructValue(d *Decoder, v reflect.Value) error {
 		return nil
 	}
 
-	fields := structs.Fields(v.Type(), d.structTag, d.flags&includeUnexportedFlag != 0)
+	fields := structs.Fields(v.Type(), d.structTag, d.flags&includeUnexportedFlag != 0, d.flags&forceAsArrayFlag != 0)
 	if n != len(fields.List) {
 		return errArrayStruct
 	}
@@ -334,7 +334,7 @@ func (d *Decoder) decodeStruct(v reflect.Value, n int) error {
 		return nil
 	}
 
-	fields := structs.Fields(v.Type(), d.structTag, d.flags&includeUnexportedFlag != 0)
+	fields := structs.Fields(v.Type(), d.structTag, d.flags&includeUnexportedFlag != 0, d.flags&forceAsArrayFlag != 0)
 	for i := 0; i < n; i++ {
 		name, err := d.decodeStringTemp()
 		if err != nil {

--- a/decode_number.go
+++ b/decode_number.go
@@ -263,7 +263,7 @@ func decodeFloat32Value(d *Decoder, v reflect.Value) error {
 	if err != nil {
 		return err
 	}
-	v.SetFloat(float64(f))
+	d.reflectSetFloat(v, float64(f))
 	return nil
 }
 
@@ -272,7 +272,7 @@ func decodeFloat64Value(d *Decoder, v reflect.Value) error {
 	if err != nil {
 		return err
 	}
-	v.SetFloat(f)
+	d.reflectSetFloat(v, f)
 	return nil
 }
 
@@ -281,7 +281,7 @@ func decodeInt64Value(d *Decoder, v reflect.Value) error {
 	if err != nil {
 		return err
 	}
-	v.SetInt(n)
+	d.reflectSetInt(v, n)
 	return nil
 }
 
@@ -290,6 +290,6 @@ func decodeUint64Value(d *Decoder, v reflect.Value) error {
 	if err != nil {
 		return err
 	}
-	v.SetUint(n)
+	d.reflectSetUint(v, n)
 	return nil
 }

--- a/decode_slice.go
+++ b/decode_slice.go
@@ -36,7 +36,7 @@ func (d *Decoder) arrayLen(c byte) (int, error) {
 }
 
 func decodeStringSliceValue(d *Decoder, v reflect.Value) error {
-	ptr := v.Addr().Convert(sliceStringPtrType).Interface().(*[]string)
+	ptr := d.reflectStringSlicePtr(v.Addr().Convert(sliceStringPtrType))
 	return d.decodeStringSlicePtr(ptr)
 }
 

--- a/decode_string.go
+++ b/decode_string.go
@@ -64,7 +64,7 @@ func decodeStringValue(d *Decoder, v reflect.Value) error {
 	if err != nil {
 		return err
 	}
-	v.SetString(s)
+	d.reflectSetString(v, s)
 	return nil
 }
 
@@ -165,7 +165,7 @@ func decodeBytesValue(d *Decoder, v reflect.Value) error {
 		return err
 	}
 
-	v.SetBytes(b)
+	d.reflectSetBytes(v, b)
 
 	return nil
 }

--- a/decode_unexported.go
+++ b/decode_unexported.go
@@ -73,9 +73,16 @@ func (d *Decoder) reflectSetMapIndex(v reflect.Value, key reflect.Value, elem re
 	reflectExportValue(v).SetMapIndex(key, elem)
 }
 
-func (d *Decoder) reflectStringSlicePtr(v reflect.Value) *[]string {
-	if d.flags&includeUnexportedFlag == 0 || v.CanInterface() {
-		return v.Interface().(*[]string)
+func (d *Decoder) reflectStringSlicePtr(vPtr reflect.Value) *[]string {
+	if d.flags&includeUnexportedFlag == 0 || vPtr.CanInterface() {
+		return vPtr.Interface().(*[]string)
 	}
-	return (*[]string)(v.UnsafePointer())
+	return (*[]string)(vPtr.UnsafePointer())
+}
+
+func (d *Decoder) reflectMapStringStringPtr(vPtr reflect.Value) *map[string]string {
+	if d.flags&includeUnexportedFlag == 0 || vPtr.CanInterface() {
+		return vPtr.Interface().(*map[string]string)
+	}
+	return (*map[string]string)(vPtr.UnsafePointer())
 }

--- a/decode_unexported.go
+++ b/decode_unexported.go
@@ -72,3 +72,10 @@ func (d *Decoder) reflectSetMapIndex(v reflect.Value, key reflect.Value, elem re
 	}
 	reflectExportValue(v).SetMapIndex(key, elem)
 }
+
+func (d *Decoder) reflectStringSlicePtr(v reflect.Value) *[]string {
+	if d.flags&includeUnexportedFlag == 0 || v.CanInterface() {
+		return v.Interface().(*[]string)
+	}
+	return (*[]string)(v.UnsafePointer())
+}

--- a/decode_unexported.go
+++ b/decode_unexported.go
@@ -64,3 +64,11 @@ func (d *Decoder) reflectSet(v reflect.Value, x reflect.Value) {
 	}
 	reflectExportValue(v).Set(x)
 }
+
+func (d *Decoder) reflectSetMapIndex(v reflect.Value, key reflect.Value, elem reflect.Value) {
+	if d.flags&includeUnexportedFlag == 0 || v.CanSet() {
+		v.SetMapIndex(key, elem)
+		return
+	}
+	reflectExportValue(v).SetMapIndex(key, elem)
+}

--- a/decode_unexported.go
+++ b/decode_unexported.go
@@ -10,7 +10,7 @@ func reflectExportValue(v reflect.Value) reflect.Value {
 }
 
 func (d *Decoder) reflectSetBool(v reflect.Value, x bool) {
-	if d.flags&includeUnexportedFlag == 0 || v.CanSet() {
+	if d.flags&decodeIncludeUnexportedFlag == 0 || v.CanSet() {
 		v.SetBool(x)
 		return
 	}
@@ -18,7 +18,7 @@ func (d *Decoder) reflectSetBool(v reflect.Value, x bool) {
 }
 
 func (d *Decoder) reflectSetInt(v reflect.Value, x int64) {
-	if d.flags&includeUnexportedFlag == 0 || v.CanSet() {
+	if d.flags&decodeIncludeUnexportedFlag == 0 || v.CanSet() {
 		v.SetInt(x)
 		return
 	}
@@ -26,7 +26,7 @@ func (d *Decoder) reflectSetInt(v reflect.Value, x int64) {
 }
 
 func (d *Decoder) reflectSetUint(v reflect.Value, x uint64) {
-	if d.flags&includeUnexportedFlag == 0 || v.CanSet() {
+	if d.flags&decodeIncludeUnexportedFlag == 0 || v.CanSet() {
 		v.SetUint(x)
 		return
 	}
@@ -34,7 +34,7 @@ func (d *Decoder) reflectSetUint(v reflect.Value, x uint64) {
 }
 
 func (d *Decoder) reflectSetFloat(v reflect.Value, x float64) {
-	if d.flags&includeUnexportedFlag == 0 || v.CanSet() {
+	if d.flags&decodeIncludeUnexportedFlag == 0 || v.CanSet() {
 		v.SetFloat(x)
 		return
 	}
@@ -42,7 +42,7 @@ func (d *Decoder) reflectSetFloat(v reflect.Value, x float64) {
 }
 
 func (d *Decoder) reflectSetString(v reflect.Value, x string) {
-	if d.flags&includeUnexportedFlag == 0 || v.CanSet() {
+	if d.flags&decodeIncludeUnexportedFlag == 0 || v.CanSet() {
 		v.SetString(x)
 		return
 	}
@@ -50,7 +50,7 @@ func (d *Decoder) reflectSetString(v reflect.Value, x string) {
 }
 
 func (d *Decoder) reflectSetBytes(v reflect.Value, x []byte) {
-	if d.flags&includeUnexportedFlag == 0 || v.CanSet() {
+	if d.flags&decodeIncludeUnexportedFlag == 0 || v.CanSet() {
 		v.SetBytes(x)
 		return
 	}
@@ -58,7 +58,7 @@ func (d *Decoder) reflectSetBytes(v reflect.Value, x []byte) {
 }
 
 func (d *Decoder) reflectSet(v reflect.Value, x reflect.Value) {
-	if d.flags&includeUnexportedFlag == 0 || v.CanSet() {
+	if d.flags&decodeIncludeUnexportedFlag == 0 || v.CanSet() {
 		v.Set(x)
 		return
 	}
@@ -66,7 +66,7 @@ func (d *Decoder) reflectSet(v reflect.Value, x reflect.Value) {
 }
 
 func (d *Decoder) reflectSetMapIndex(v reflect.Value, key reflect.Value, elem reflect.Value) {
-	if d.flags&includeUnexportedFlag == 0 || v.CanSet() {
+	if d.flags&decodeIncludeUnexportedFlag == 0 || v.CanSet() {
 		v.SetMapIndex(key, elem)
 		return
 	}
@@ -74,14 +74,14 @@ func (d *Decoder) reflectSetMapIndex(v reflect.Value, key reflect.Value, elem re
 }
 
 func (d *Decoder) reflectStringSlicePtr(vPtr reflect.Value) *[]string {
-	if d.flags&includeUnexportedFlag == 0 || vPtr.CanInterface() {
+	if d.flags&decodeIncludeUnexportedFlag == 0 || vPtr.CanInterface() {
 		return vPtr.Interface().(*[]string)
 	}
 	return (*[]string)(vPtr.UnsafePointer())
 }
 
 func (d *Decoder) reflectMapStringStringPtr(vPtr reflect.Value) *map[string]string {
-	if d.flags&includeUnexportedFlag == 0 || vPtr.CanInterface() {
+	if d.flags&decodeIncludeUnexportedFlag == 0 || vPtr.CanInterface() {
 		return vPtr.Interface().(*map[string]string)
 	}
 	return (*map[string]string)(vPtr.UnsafePointer())

--- a/decode_unexported.go
+++ b/decode_unexported.go
@@ -1,0 +1,66 @@
+package msgpack
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+func reflectExportValue(v reflect.Value) reflect.Value {
+	return reflect.NewAt(v.Type(), unsafe.Pointer(v.UnsafeAddr())).Elem()
+}
+
+func (d *Decoder) reflectSetBool(v reflect.Value, x bool) {
+	if d.flags&includeUnexportedFlag == 0 || v.CanSet() {
+		v.SetBool(x)
+		return
+	}
+	reflectExportValue(v).SetBool(x)
+}
+
+func (d *Decoder) reflectSetInt(v reflect.Value, x int64) {
+	if d.flags&includeUnexportedFlag == 0 || v.CanSet() {
+		v.SetInt(x)
+		return
+	}
+	reflectExportValue(v).SetInt(x)
+}
+
+func (d *Decoder) reflectSetUint(v reflect.Value, x uint64) {
+	if d.flags&includeUnexportedFlag == 0 || v.CanSet() {
+		v.SetUint(x)
+		return
+	}
+	reflectExportValue(v).SetUint(x)
+}
+
+func (d *Decoder) reflectSetFloat(v reflect.Value, x float64) {
+	if d.flags&includeUnexportedFlag == 0 || v.CanSet() {
+		v.SetFloat(x)
+		return
+	}
+	reflectExportValue(v).SetFloat(x)
+}
+
+func (d *Decoder) reflectSetString(v reflect.Value, x string) {
+	if d.flags&includeUnexportedFlag == 0 || v.CanSet() {
+		v.SetString(x)
+		return
+	}
+	reflectExportValue(v).SetString(x)
+}
+
+func (d *Decoder) reflectSetBytes(v reflect.Value, x []byte) {
+	if d.flags&includeUnexportedFlag == 0 || v.CanSet() {
+		v.SetBytes(x)
+		return
+	}
+	reflectExportValue(v).SetBytes(x)
+}
+
+func (d *Decoder) reflectSet(v reflect.Value, x reflect.Value) {
+	if d.flags&includeUnexportedFlag == 0 || v.CanSet() {
+		v.Set(x)
+		return
+	}
+	reflectExportValue(v).Set(x)
+}

--- a/encode.go
+++ b/encode.go
@@ -18,6 +18,7 @@ const (
 	useInternedStringsFlag
 	omitEmptyFlag
 	includeUnexportedFlag
+	forceAsArrayFlag
 )
 
 type writer interface {
@@ -203,6 +204,14 @@ func (e *Encoder) IncludeUnexported(included bool) {
 		e.flags |= includeUnexportedFlag
 	} else {
 		e.flags &= ^includeUnexportedFlag
+	}
+}
+
+func (e *Encoder) SetForceAsArray(forced bool) {
+	if forced {
+		e.flags |= forceAsArrayFlag
+	} else {
+		e.flags &= ^forceAsArrayFlag
 	}
 }
 

--- a/encode.go
+++ b/encode.go
@@ -82,8 +82,6 @@ type Encoder struct {
 	buf       []byte
 	timeBuf   []byte
 	flags     uint32
-
-	ignoredStructFields map[reflect.Type]map[string]struct{}
 }
 
 // NewEncoder returns a new encoder that writes to w.
@@ -206,18 +204,6 @@ func (e *Encoder) IncludeUnexported(included bool) {
 	} else {
 		e.flags &= ^includeUnexportedFlag
 	}
-}
-
-// IgnoreStructField causes the Encoder to ignore the field whose name is fieldName of the struct whose type is structType.
-// This method is similar to `msgpack:"-"` tag.
-func (e *Encoder) IgnoreStructField(structType reflect.Type, fieldName string) {
-	if e.ignoredStructFields == nil {
-		e.ignoredStructFields = make(map[reflect.Type]map[string]struct{})
-	}
-	if e.ignoredStructFields[structType] == nil {
-		e.ignoredStructFields[structType] = make(map[string]struct{})
-	}
-	e.ignoredStructFields[structType][fieldName] = struct{}{}
 }
 
 func (e *Encoder) Encode(v interface{}) error {

--- a/encode.go
+++ b/encode.go
@@ -103,9 +103,6 @@ func (e *Encoder) Writer() io.Writer {
 // Reset discards any buffered data, resets all state, and switches the writer to write to w.
 func (e *Encoder) Reset(w io.Writer) {
 	e.ResetDict(w, nil)
-	for k := range e.ignoredStructFields {
-		delete(e.ignoredStructFields, k)
-	}
 }
 
 // ResetDict is like Reset, but also resets the dict.

--- a/encode.go
+++ b/encode.go
@@ -17,8 +17,8 @@ const (
 	useCompactFloatsFlag
 	useInternedStringsFlag
 	omitEmptyFlag
-	includeUnexportedFlag
-	forceAsArrayFlag
+	encodeIncludeUnexportedFlag
+	encodeForceAsArrayFlag
 )
 
 type writer interface {
@@ -201,17 +201,17 @@ func (e *Encoder) UseInternedStrings(on bool) {
 // IncludeUnexported causes the Encoder to encode unexported fields
 func (e *Encoder) IncludeUnexported(included bool) {
 	if included {
-		e.flags |= includeUnexportedFlag
+		e.flags |= encodeIncludeUnexportedFlag
 	} else {
-		e.flags &= ^includeUnexportedFlag
+		e.flags &= ^encodeIncludeUnexportedFlag
 	}
 }
 
 func (e *Encoder) SetForceAsArray(forced bool) {
 	if forced {
-		e.flags |= forceAsArrayFlag
+		e.flags |= encodeForceAsArrayFlag
 	} else {
-		e.flags &= ^forceAsArrayFlag
+		e.flags &= ^encodeForceAsArrayFlag
 	}
 }
 

--- a/encode_hook.go
+++ b/encode_hook.go
@@ -2,20 +2,31 @@ package msgpack
 
 import (
 	"reflect"
+	"unsafe"
 )
+
+var encodeHookType = reflect.TypeOf((*EncodeHook)(nil)).Elem()
 
 type EncodeHook interface {
 	BeforeMsgpackMarshal() error
 }
 
-func encodeHook(strct reflect.Value) error {
-	if !strct.CanAddr() {
+func encodeHook(v reflect.Value) error {
+	if !v.CanAddr() {
 		return nil
 	}
-	if !strct.CanSet() {
+	vPtr := v.Addr()
+
+	// early exit
+	if !vPtr.Type().AssignableTo(encodeHookType) {
 		return nil
 	}
-	if hook, ok := strct.Addr().Interface().(EncodeHook); ok {
+
+	if !vPtr.CanInterface() {
+		vPtr = reflect.NewAt(v.Type(), unsafe.Pointer(v.UnsafeAddr()))
+	}
+
+	if hook, ok := vPtr.Interface().(EncodeHook); ok {
 		if err := hook.BeforeMsgpackMarshal(); err != nil {
 			return err
 		}

--- a/encode_hook.go
+++ b/encode_hook.go
@@ -1,0 +1,24 @@
+package msgpack
+
+import (
+	"reflect"
+)
+
+type EncodeHook interface {
+	BeforeMsgpackMarshal() error
+}
+
+func encodeHook(strct reflect.Value) error {
+	if !strct.CanAddr() {
+		return nil
+	}
+	if !strct.CanSet() {
+		return nil
+	}
+	if hook, ok := strct.Addr().Interface().(EncodeHook); ok {
+		if err := hook.BeforeMsgpackMarshal(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/encode_map.go
+++ b/encode_map.go
@@ -206,7 +206,7 @@ func (e *Encoder) EncodeMapLen(l int) error {
 }
 
 func encodeStructValue(e *Encoder, strct reflect.Value) error {
-	structFields := structs.Fields(strct.Type(), e.structTag, e.flags&includeUnexportedFlag != 0, e.ignoredStructFields[strct.Type()])
+	structFields := structs.Fields(strct.Type(), e.structTag, e.flags&includeUnexportedFlag != 0)
 	if e.flags&arrayEncodedStructsFlag != 0 || structFields.AsArray {
 		return encodeStructValueAsArray(e, strct, structFields.List)
 	}

--- a/encode_map.go
+++ b/encode_map.go
@@ -206,7 +206,7 @@ func (e *Encoder) EncodeMapLen(l int) error {
 }
 
 func encodeStructValue(e *Encoder, strct reflect.Value) error {
-	structFields := structs.Fields(strct.Type(), e.structTag, e.flags&includeUnexportedFlag != 0, e.flags&forceAsArrayFlag != 0)
+	structFields := structs.Fields(strct.Type(), e.structTag, e.flags&encodeIncludeUnexportedFlag != 0, e.flags&encodeForceAsArrayFlag != 0)
 	if e.flags&arrayEncodedStructsFlag != 0 || structFields.AsArray {
 		return encodeStructValueAsArray(e, strct, structFields.List)
 	}

--- a/encode_map.go
+++ b/encode_map.go
@@ -206,7 +206,7 @@ func (e *Encoder) EncodeMapLen(l int) error {
 }
 
 func encodeStructValue(e *Encoder, strct reflect.Value) error {
-	structFields := structs.Fields(strct.Type(), e.structTag, e.flags&includeUnexportedFlag != 0)
+	structFields := structs.Fields(strct.Type(), e.structTag, e.flags&includeUnexportedFlag != 0, e.flags&forceAsArrayFlag != 0)
 	if e.flags&arrayEncodedStructsFlag != 0 || structFields.AsArray {
 		return encodeStructValueAsArray(e, strct, structFields.List)
 	}

--- a/encode_map.go
+++ b/encode_map.go
@@ -39,11 +39,19 @@ func encodeMapStringBoolValue(e *Encoder, v reflect.Value) error {
 		return err
 	}
 
-	m := v.Convert(mapStringBoolType).Interface().(map[string]bool)
+	vConverted := v.Convert(mapStringBoolType)
 	if e.flags&sortMapKeysFlag != 0 {
+		if !vConverted.CanInterface() {
+			return encodeSortedMapStringBoolUnexported(e, vConverted)
+		}
+		m := vConverted.Interface().(map[string]bool)
 		return e.encodeSortedMapStringBool(m)
 	}
 
+	if !vConverted.CanInterface() {
+		return encodeMapStringBoolValueUnexported(e, vConverted)
+	}
+	m := vConverted.Interface().(map[string]bool)
 	for mk, mv := range m {
 		if err := e.EncodeString(mk); err != nil {
 			return err
@@ -65,11 +73,19 @@ func encodeMapStringStringValue(e *Encoder, v reflect.Value) error {
 		return err
 	}
 
-	m := v.Convert(mapStringStringType).Interface().(map[string]string)
+	vConverted := v.Convert(mapStringStringType)
 	if e.flags&sortMapKeysFlag != 0 {
+		if !vConverted.CanInterface() {
+			return encodeSortedMapStringStringUnexported(e, vConverted)
+		}
+		m := vConverted.Interface().(map[string]string)
 		return e.encodeSortedMapStringString(m)
 	}
 
+	if !vConverted.CanInterface() {
+		return encodeMapStringStringValueUnexported(e, vConverted)
+	}
+	m := vConverted.Interface().(map[string]string)
 	for mk, mv := range m {
 		if err := e.EncodeString(mk); err != nil {
 			return err

--- a/encode_slice.go
+++ b/encode_slice.go
@@ -29,7 +29,7 @@ func encodeByteArrayValue(e *Encoder, v reflect.Value) error {
 
 	e.buf = grow(e.buf, v.Len())
 	// v.CanSet() means v is exported
-	if e.flags&includeUnexportedFlag == 0 || v.CanSet() {
+	if e.flags&encodeIncludeUnexportedFlag == 0 || v.CanSet() {
 		reflect.Copy(reflect.ValueOf(e.buf), v)
 	} else {
 		e.writeByteArrayUnexportedToBuf(v)

--- a/encode_slice.go
+++ b/encode_slice.go
@@ -99,7 +99,7 @@ func (e *Encoder) EncodeArrayLen(l int) error {
 }
 
 func encodeStringSliceValue(e *Encoder, v reflect.Value) error {
-	ss := v.Convert(stringSliceType).Interface().([]string)
+	ss := e.reflectStringSlice(v.Convert(stringSliceType))
 	return e.encodeStringSlice(ss)
 }
 

--- a/encode_slice.go
+++ b/encode_slice.go
@@ -28,7 +28,12 @@ func encodeByteArrayValue(e *Encoder, v reflect.Value) error {
 	}
 
 	e.buf = grow(e.buf, v.Len())
-	reflect.Copy(reflect.ValueOf(e.buf), v)
+	// v.CanSet() means v is exported
+	if e.flags&includeUnexportedFlag == 0 || v.CanSet() {
+		reflect.Copy(reflect.ValueOf(e.buf), v)
+	} else {
+		e.writeByteArrayUnexportedToBuf(v)
+	}
 	return e.write(e.buf)
 }
 

--- a/encode_unexported.go
+++ b/encode_unexported.go
@@ -1,0 +1,13 @@
+package msgpack
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+func (e *Encoder) reflectStringSlice(v reflect.Value) []string {
+	if v.CanInterface() {
+		return v.Interface().([]string)
+	}
+	return unsafe.Slice((*string)(v.UnsafePointer()), v.Len())
+}

--- a/encode_unexported.go
+++ b/encode_unexported.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (e *Encoder) reflectStringSlice(v reflect.Value) []string {
-	if e.flags&includeUnexportedFlag == 0 || v.CanInterface() {
+	if e.flags&encodeIncludeUnexportedFlag == 0 || v.CanInterface() {
 		return v.Interface().([]string)
 	}
 	return unsafe.Slice((*string)(v.UnsafePointer()), v.Len())

--- a/encode_unexported.go
+++ b/encode_unexported.go
@@ -2,6 +2,7 @@ package msgpack
 
 import (
 	"reflect"
+	"sort"
 	"unsafe"
 )
 
@@ -10,4 +11,78 @@ func (e *Encoder) reflectStringSlice(v reflect.Value) []string {
 		return v.Interface().([]string)
 	}
 	return unsafe.Slice((*string)(v.UnsafePointer()), v.Len())
+}
+
+func encodeMapStringBoolValueUnexported(e *Encoder, v reflect.Value) error {
+	iter := v.MapRange()
+	for iter.Next() {
+		mk := iter.Key().String()
+		mv := iter.Value().Bool()
+		if err := e.EncodeString(mk); err != nil {
+			return err
+		}
+		if err := e.EncodeBool(mv); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func encodeMapStringStringValueUnexported(e *Encoder, v reflect.Value) error {
+	iter := v.MapRange()
+	for iter.Next() {
+		mk := iter.Key().String()
+		mv := iter.Value().String()
+		if err := e.EncodeString(mk); err != nil {
+			return err
+		}
+		if err := e.EncodeString(mv); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func encodeSortedMapStringStringUnexported(e *Encoder, v reflect.Value) error {
+	rkeys := v.MapKeys()
+	keys := make([]string, len(rkeys))
+	for i, rkey := range rkeys {
+		keys[i] = rkey.String()
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		err := e.EncodeString(k)
+		if err != nil {
+			return err
+		}
+		val := v.MapIndex(reflect.ValueOf(k)).String()
+		if err = e.EncodeString(val); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func encodeSortedMapStringBoolUnexported(e *Encoder, v reflect.Value) error {
+	rkeys := v.MapKeys()
+	keys := make([]string, len(rkeys))
+	for i, rkey := range rkeys {
+		keys[i] = rkey.String()
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		err := e.EncodeString(k)
+		if err != nil {
+			return err
+		}
+		val := v.MapIndex(reflect.ValueOf(k)).Bool()
+		if err = e.EncodeBool(val); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/encode_unexported.go
+++ b/encode_unexported.go
@@ -7,12 +7,22 @@ import (
 )
 
 func (e *Encoder) reflectStringSlice(v reflect.Value) []string {
-	if v.CanInterface() {
+	if e.flags&includeUnexportedFlag == 0 || v.CanInterface() {
 		return v.Interface().([]string)
 	}
 	return unsafe.Slice((*string)(v.UnsafePointer()), v.Len())
 }
 
+func (e *Encoder) writeByteArrayUnexportedToBuf(v reflect.Value) {
+	n := v.Len()
+	for i := 0; i < n; i++ {
+		e.buf[i] = byte(v.Index(i).Uint())
+	}
+}
+
+// Iterate over reflect.Value which is a map[string]string and encode its entries.
+// Since reflect.Value v is an unexported field, we can not `.Interface().(map[string]string)`.
+// Instead, we use `.MapRange()` to iterate over its entries.
 func encodeMapStringBoolValueUnexported(e *Encoder, v reflect.Value) error {
 	iter := v.MapRange()
 	for iter.Next() {
@@ -28,6 +38,9 @@ func encodeMapStringBoolValueUnexported(e *Encoder, v reflect.Value) error {
 	return nil
 }
 
+// Iterate over reflect.Value which is a map[string]bool and encode its entries.
+// Since reflect.Value v is an unexported field, we can not `.Interface().(map[string]bool)`.
+// Instead, we use `.MapRange()` to iterate over its entries.
 func encodeMapStringStringValueUnexported(e *Encoder, v reflect.Value) error {
 	iter := v.MapRange()
 	for iter.Next() {
@@ -43,7 +56,13 @@ func encodeMapStringStringValueUnexported(e *Encoder, v reflect.Value) error {
 	return nil
 }
 
+// Iterate over reflect.Value which is a map[string]string and encode its entries ordered by keys.
+// Since reflect.Value v is an unexported field, we can not `.Interface().(map[string]string)`.
+// Instead, we use `.MapRange()` to iterate over its entries.
 func encodeSortedMapStringStringUnexported(e *Encoder, v reflect.Value) error {
+	if v.Kind() != reflect.Map {
+		panic("expect reflect.Map")
+	}
 	rkeys := v.MapKeys()
 	keys := make([]string, len(rkeys))
 	for i, rkey := range rkeys {
@@ -65,6 +84,9 @@ func encodeSortedMapStringStringUnexported(e *Encoder, v reflect.Value) error {
 	return nil
 }
 
+// Iterate over reflect.Value which is a map[string]bool and encode its entries ordered by keys.
+// Since reflect.Value v is an unexported field, we can not `.Interface().(map[string]bool)`.
+// Instead, we use `.MapRange()` to iterate over its entries.
 func encodeSortedMapStringBoolUnexported(e *Encoder, v reflect.Value) error {
 	rkeys := v.MapKeys()
 	keys := make([]string, len(rkeys))

--- a/extra/msgpappengine/appengine.go
+++ b/extra/msgpappengine/appengine.go
@@ -3,7 +3,7 @@ package msgpappengine
 import (
 	"reflect"
 
-	"github.com/vmihailenco/msgpack/v5"
+	"github.com/KyberNetwork/msgpack/v5"
 	ds "google.golang.org/appengine/datastore"
 )
 

--- a/extra/msgpappengine/go.mod
+++ b/extra/msgpappengine/go.mod
@@ -1,10 +1,10 @@
-module github.com/vmihailenco/msgpack/extra/appengine
+module github.com/KyberNetwork/msgpack/extra/appengine
 
 go 1.15
 
-replace github.com/vmihailenco/msgpack/v5 => ../..
+replace github.com/KyberNetwork/msgpack/v5 => ../..
 
 require (
-	github.com/vmihailenco/msgpack/v5 v5.4.1
+	github.com/KyberNetwork/msgpack/v5 v5.0.0-20240604102013-9c8e2bd45877
 	google.golang.org/appengine v1.6.7
 )

--- a/extra/msgpappengine/go.sum
+++ b/extra/msgpappengine/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/holiman/uint256 v1.2.4 h1:jUc4Nk8fm9jZabQuqr2JzednajVmBpC+oiTiXZJEApU=
+github.com/holiman/uint256 v1.2.4/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/holiman/uint256 v1.2.4
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/holiman/uint256 v1.2.4 h1:jUc4Nk8fm9jZabQuqr2JzednajVmBpC+oiTiXZJEApU=
+github.com/holiman/uint256 v1.2.4/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/intern.go
+++ b/intern.go
@@ -33,7 +33,7 @@ func decodeInternedStringExt(d *Decoder, v reflect.Value, extLen int) error {
 		return err
 	}
 
-	v.SetString(s)
+	d.reflectSetString(v, s)
 	return nil
 }
 
@@ -102,7 +102,7 @@ func (e *Encoder) encodeInternedStringIndex(idx int) error {
 func decodeInternedInterfaceValue(d *Decoder, v reflect.Value) error {
 	s, err := d.decodeInternedString(true)
 	if err == nil {
-		v.Set(reflect.ValueOf(s))
+		d.reflectSet(v, reflect.ValueOf(s))
 		return nil
 	}
 	if err != nil {
@@ -123,7 +123,7 @@ func decodeInternedStringValue(d *Decoder, v reflect.Value) error {
 		return err
 	}
 
-	v.SetString(s)
+	d.reflectSetString(v, s)
 	return nil
 }
 

--- a/msgpack_forked_test.go
+++ b/msgpack_forked_test.go
@@ -133,6 +133,7 @@ func TestMarshalUnmarshalForked(t *testing.T) {
 	var encoded bytes.Buffer
 	en := msgpack.NewEncoder(&encoded)
 	en.IncludeUnexported(true)
+	en.SetForceAsArray(true)
 
 	err := en.Encode(expected)
 	require.NoError(t, err)
@@ -140,6 +141,7 @@ func TestMarshalUnmarshalForked(t *testing.T) {
 	decoded := new(Foo)
 	de := msgpack.NewDecoder(&encoded)
 	de.IncludeUnexported(true)
+	en.SetForceAsArray(true)
 
 	err = de.Decode(decoded)
 	require.NoError(t, err)

--- a/msgpack_forked_test.go
+++ b/msgpack_forked_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/KyberNetwork/msgpack/v5"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
@@ -30,6 +31,9 @@ type Foo struct {
 	epsilon IBar
 	zeta    map[uint64]string
 	eta     []string
+	theta   map[string]string
+	iota_   map[string]bool
+	kappa   map[string]struct{}
 	ignored uint64
 }
 
@@ -59,7 +63,19 @@ func TestFoo(t *testing.T) {
 		zeta: map[uint64]string{
 			69696969: "foo",
 		},
-		eta:     []string{"foo", "bar"},
+		eta: []string{"foo", "bar"},
+		theta: map[string]string{
+			"foo": "bar",
+			"abc": "def",
+		},
+		iota_: map[string]bool{
+			"foo": true,
+			"abc": false,
+		},
+		kappa: map[string]struct{}{
+			"foo": {},
+			"bar": {},
+		},
 		ignored: 69696969,
 	}
 
@@ -78,6 +94,8 @@ func TestFoo(t *testing.T) {
 
 	err = de.Decode(decoded)
 	require.NoError(t, err)
+
+	spew.Dump(decoded)
 
 	require.Zerof(t, decoded.ignored, "ignored fields via IgnoreStructField must be zero")
 	decoded.ignored = expected.ignored

--- a/msgpack_forked_test.go
+++ b/msgpack_forked_test.go
@@ -1,0 +1,81 @@
+package msgpack_test
+
+import (
+	"bytes"
+	"math"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/KyberNetwork/msgpack/v5"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+type Bar struct {
+	alpha *uint256.Int
+}
+
+type IBar interface {
+	Bar()
+}
+
+func (*Bar) Bar() {}
+
+type Foo struct {
+	alpha   *uint64
+	beta    *big.Int
+	gamma   *uint256.Int
+	delta   uint256.Int
+	epsilon IBar
+	ignored uint64
+}
+
+func (f *Foo) BeforeMsgpackMarshal() error {
+	*f.alpha += 1
+	return nil
+}
+
+func (f *Foo) AfterMsgpackUnmarshal() error {
+	*f.alpha -= 1
+	return nil
+}
+
+func newUint64(v uint64) *uint64 { return &v }
+
+func TestFoo(t *testing.T) {
+	msgpack.RegisterConcreteType(&Bar{})
+
+	expected := &Foo{
+		alpha: newUint64(9999999999999999),
+		beta:  new(big.Int).Exp(new(big.Int).SetUint64(math.MaxUint64), big.NewInt(4), nil),
+		gamma: new(uint256.Int).Exp(new(uint256.Int).SetUint64(math.MaxUint64), uint256.NewInt(4)),
+		delta: *new(uint256.Int).Exp(new(uint256.Int).SetUint64(math.MaxUint64), uint256.NewInt(4)),
+		epsilon: &Bar{
+			alpha: new(uint256.Int).Exp(new(uint256.Int).SetUint64(math.MaxUint64), uint256.NewInt(4)),
+		},
+		ignored: 69696969,
+	}
+
+	var encoded bytes.Buffer
+	en := msgpack.NewEncoder(&encoded)
+	en.IncludeUnexported(true)
+	en.IgnoreStructField(reflect.TypeOf((*Foo)(nil)).Elem(), "ignored")
+
+	err := en.Encode(expected)
+	require.NoError(t, err)
+
+	decoded := new(Foo)
+	de := msgpack.NewDecoder(&encoded)
+	de.IncludeUnexported(true)
+	de.IgnoreStructField(reflect.TypeOf((*Foo)(nil)).Elem(), "ignored")
+
+	err = de.Decode(decoded)
+	require.NoError(t, err)
+
+	require.Zerof(t, decoded.ignored, "ignored fields via IgnoreStructField must be zero")
+	decoded.ignored = expected.ignored
+
+	*expected.alpha -= 1
+	require.EqualValues(t, expected, decoded)
+}

--- a/msgpack_forked_test.go
+++ b/msgpack_forked_test.go
@@ -29,6 +29,7 @@ type Foo struct {
 	delta   uint256.Int
 	epsilon IBar
 	zeta    map[uint64]string
+	eta     []string
 	ignored uint64
 }
 
@@ -58,6 +59,7 @@ func TestFoo(t *testing.T) {
 		zeta: map[uint64]string{
 			69696969: "foo",
 		},
+		eta:     []string{"foo", "bar"},
 		ignored: 69696969,
 	}
 

--- a/msgpack_forked_test.go
+++ b/msgpack_forked_test.go
@@ -2,9 +2,11 @@ package msgpack_test
 
 import (
 	"bytes"
+	"encoding/hex"
 	"math"
 	"math/big"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/KyberNetwork/msgpack/v5"
@@ -12,6 +14,23 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
+
+type Address [20]byte
+
+func hexToAddress(s string) Address {
+	s = strings.TrimPrefix(s, "0x")
+	var a Address
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return a
+	}
+	if len(b) > 20 {
+		copy(a[:], b[len(b)-20:])
+	} else {
+		copy(a[20-len(b):], b[:])
+	}
+	return a
+}
 
 type Bar struct {
 	alpha *uint256.Int
@@ -22,6 +41,12 @@ type IBar interface {
 }
 
 func (*Bar) Bar() {}
+
+type tokenInfo struct {
+	indexPlus1 uint8
+	scale      uint8
+	gauge      Address
+}
 
 type Foo struct {
 	alpha   *uint64
@@ -34,6 +59,7 @@ type Foo struct {
 	theta   map[string]string
 	iota_   map[string]bool
 	kappa   map[string]struct{}
+	lambda  map[string]tokenInfo
 	ignored uint64
 }
 
@@ -75,6 +101,13 @@ func TestMarshalUnmarshalUnexportedFields(t *testing.T) {
 		kappa: map[string]struct{}{
 			"foo": {},
 			"bar": {},
+		},
+		lambda: map[string]tokenInfo{
+			"foo": {
+				indexPlus1: 99,
+				scale:      99,
+				gauge:      hexToAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
+			},
 		},
 		ignored: 69696969,
 	}

--- a/msgpack_forked_test.go
+++ b/msgpack_forked_test.go
@@ -28,6 +28,7 @@ type Foo struct {
 	gamma   *uint256.Int
 	delta   uint256.Int
 	epsilon IBar
+	zeta    map[uint64]string
 	ignored uint64
 }
 
@@ -53,6 +54,9 @@ func TestFoo(t *testing.T) {
 		delta: *new(uint256.Int).Exp(new(uint256.Int).SetUint64(math.MaxUint64), uint256.NewInt(4)),
 		epsilon: &Bar{
 			alpha: new(uint256.Int).Exp(new(uint256.Int).SetUint64(math.MaxUint64), uint256.NewInt(4)),
+		},
+		zeta: map[uint64]string{
+			69696969: "foo",
 		},
 		ignored: 69696969,
 	}

--- a/msgpack_forked_test.go
+++ b/msgpack_forked_test.go
@@ -49,7 +49,7 @@ func (f *Foo) AfterMsgpackUnmarshal() error {
 
 func newUint64(v uint64) *uint64 { return &v }
 
-func TestFoo(t *testing.T) {
+func TestMarshalUnmarshalUnexportedFields(t *testing.T) {
 	msgpack.RegisterConcreteType(&Bar{})
 
 	expected := &Foo{

--- a/msgpack_forked_test.go
+++ b/msgpack_forked_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"math"
 	"math/big"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -61,7 +60,6 @@ type Foo struct {
 	kappa   map[string]struct{}
 	lambda  map[string]tokenInfo
 	mu      *Token
-	ignored uint64
 }
 
 func newUint64(v uint64) *uint64 { return &v }
@@ -129,14 +127,12 @@ func TestMarshalUnmarshalForked(t *testing.T) {
 			},
 			Address: "0xaaaa",
 		},
-		ignored: 69696969,
 	}
 	expected.mu.BaseCurrency.Currency = expected.mu
 
 	var encoded bytes.Buffer
 	en := msgpack.NewEncoder(&encoded)
 	en.IncludeUnexported(true)
-	en.IgnoreStructField(reflect.TypeOf((*Foo)(nil)).Elem(), "ignored")
 
 	err := en.Encode(expected)
 	require.NoError(t, err)
@@ -144,15 +140,11 @@ func TestMarshalUnmarshalForked(t *testing.T) {
 	decoded := new(Foo)
 	de := msgpack.NewDecoder(&encoded)
 	de.IncludeUnexported(true)
-	de.IgnoreStructField(reflect.TypeOf((*Foo)(nil)).Elem(), "ignored")
 
 	err = de.Decode(decoded)
 	require.NoError(t, err)
 
 	spew.Dump(decoded)
-
-	require.Zerof(t, decoded.ignored, "ignored fields via IgnoreStructField must be zero")
-	decoded.ignored = expected.ignored
 
 	require.EqualValues(t, expected, decoded)
 }

--- a/tagged_interface.go
+++ b/tagged_interface.go
@@ -1,0 +1,85 @@
+package msgpack
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/KyberNetwork/msgpack/v5/msgpcode"
+)
+
+const taggedInterfaceExtID = 127
+
+var taggedInterfaceTypeMap = map[string]reflect.Type{}
+
+func getConcreteTypeTag(v reflect.Value) (string, reflect.Type) {
+	if v.Kind() == reflect.Pointer {
+		if v.IsNil() || v.Elem().Kind() != reflect.Struct {
+			return "", nil
+		}
+	} else if v.Kind() != reflect.Struct {
+		return "", nil
+	}
+	var (
+		isPointer bool
+		typ       reflect.Type
+	)
+	if v.Kind() == reflect.Pointer {
+		isPointer = true
+		typ = v.Elem().Type()
+	} else {
+		typ = v.Type()
+	}
+	if isPointer {
+		return fmt.Sprintf("*%s %s", typ.PkgPath(), typ.Name()), typ
+	}
+	return fmt.Sprintf("%s %s", typ.PkgPath(), typ.Name()), typ
+}
+
+func RegisterConcreteType(v interface{}) error {
+	tag, typ := getConcreteTypeTag(reflect.ValueOf(v))
+	if typ == nil {
+		return fmt.Errorf("expect struct or pointer to struct")
+	}
+	taggedInterfaceTypeMap[tag] = typ
+	return nil
+}
+
+func (e *Encoder) encodeTaggedInterface(tag string, v reflect.Value) error {
+	err := e.writeCode(msgpcode.FixExt1)
+	if err != nil {
+		return err
+	}
+	err = e.writeCode(taggedInterfaceExtID)
+	if err != nil {
+		return err
+	}
+	err = e.EncodeString(tag)
+	if err != nil {
+		return err
+	}
+	err = e.EncodeValue(v.Elem())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *Decoder) decodeTaggedInterface() (interface{}, error) {
+	tag, err := d.DecodeString()
+	if err != nil {
+		return nil, err
+	}
+
+	typ, ok := taggedInterfaceTypeMap[tag]
+	if !ok {
+		return nil, fmt.Errorf("unregistered concrete type")
+	}
+
+	v := reflect.New(typ)
+	err = d.DecodeValue(v)
+	if err != nil {
+		return nil, err
+	}
+
+	return v.Interface(), nil
+}

--- a/types.go
+++ b/types.go
@@ -64,15 +64,23 @@ func newStructCache() *structCache {
 	return new(structCache)
 }
 
-func (m *structCache) Fields(typ reflect.Type, tag string, includeUnexported bool) *fields {
+func (m *structCache) Fields(typ reflect.Type, tag string, includeUnexported, forceAsArray bool) *fields {
 	key := structCacheKey{tag: tag, includeUnexported: includeUnexported, typ: typ}
 
+	var fs *fields
 	if v, ok := m.m.Load(key); ok {
-		return v.(*fields)
+		fs = v.(*fields)
+	} else {
+		fs = getFields(typ, tag, includeUnexported)
+		m.m.Store(key, fs)
 	}
 
-	fs := getFields(typ, tag, includeUnexported)
-	m.m.Store(key, fs)
+	if forceAsArray {
+		fsAsArray := &fields{}
+		*fsAsArray = *fs
+		fsAsArray.AsArray = true
+		return fsAsArray
+	}
 
 	return fs
 }
@@ -331,7 +339,7 @@ func (e *Encoder) isEmptyValue(v reflect.Value) bool {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
 		return v.Len() == 0
 	case reflect.Struct:
-		structFields := structs.Fields(v.Type(), e.structTag, e.flags&includeUnexportedFlag != 0)
+		structFields := structs.Fields(v.Type(), e.structTag, e.flags&includeUnexportedFlag != 0, e.flags&forceAsArrayFlag != 0)
 		fields := structFields.OmitEmpty(e, v)
 		return len(fields) == 0
 	case reflect.Bool:

--- a/types.go
+++ b/types.go
@@ -113,7 +113,7 @@ func (f *field) EncodeValue(e *Encoder, strct reflect.Value) error {
 }
 
 func (f *field) DecodeValue(d *Decoder, strct reflect.Value) error {
-	v := fieldByIndexAlloc(strct, f.index, d.flags&includeUnexportedFlag != 0)
+	v := fieldByIndexAlloc(strct, f.index, d.flags&decodeIncludeUnexportedFlag != 0)
 	return f.decoder(d, v)
 }
 
@@ -339,7 +339,7 @@ func (e *Encoder) isEmptyValue(v reflect.Value) bool {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
 		return v.Len() == 0
 	case reflect.Struct:
-		structFields := structs.Fields(v.Type(), e.structTag, e.flags&includeUnexportedFlag != 0, e.flags&forceAsArrayFlag != 0)
+		structFields := structs.Fields(v.Type(), e.structTag, e.flags&encodeIncludeUnexportedFlag != 0, e.flags&encodeForceAsArrayFlag != 0)
 		fields := structFields.OmitEmpty(e, v)
 		return len(fields) == 0
 	case reflect.Bool:

--- a/types_test.go
+++ b/types_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
-	"math/big"
 	"net/url"
 	"reflect"
 	"strings"
@@ -620,8 +619,6 @@ var (
 			in:  InlineDupTest{FooTest{"foo"}, FooDupTest{"foo"}},
 			out: new(InlineDupTest),
 		},
-
-		{in: big.NewInt(123), out: new(big.Int)},
 	}
 )
 


### PR DESCRIPTION
feat: allowed encode/decode unexported fields
refactor!: removed encoding.Text(Un)Marshaler and encoding.Binary(Un)Marshaler support
feat: added (Encoder).IncludeUnexported() and added (Decoder).IncludeUnexported()
feat: added interface encoding/decoding which occupied a specific extension type ID
feat: added EncodeHook and DecodeHook interfaces where (EncodeHook).BeforeMsgpackMarshal() is called before marshaling a struct and (DecodeHook).AfterMsgpackUnmarshal() is called after unmarshaling a struct
feat: added (Encoder).SetForceAsArray() and (Decoder).SetForceAsArray() to make encoder and decoder encode/decode all structs as array
test: introduced holiman/uint256 dependency for test